### PR TITLE
(fix) Fix main path

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "access": "restricted"
   },
   "description": "Web3 Algorand wallet selector",
-  "main": "index.js",
-  "unpkg": "index.js",
+  "main": "src/index.js",
+  "unpkg": "src/index.js",
   "files": [
     "*"
   ],


### PR DESCRIPTION
To use this repository instead of an NPM package, we need `main` within `package.json` to correspond to the actual source entry. For example:

```sh
yarn add https://github.com/xBacked-DAO/algorand-wallet-selector.git
```

See https://docs.npmjs.com/cli/v7/configuring-npm/package-json#main for more information

Resolves #2 