### PR TITLE
REMOVE: tailwind forms plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xbacked-dao/algorand-wallet-select",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,5 +24,5 @@ module.exports = {
     },
   },
   variants: { extend: {} },
-  plugins: [require("@tailwindcss/forms"), require("@tailwindcss/typography"), require("@tailwindcss/aspect-ratio"), require("@tailwindcss/line-clamp")],
+  plugins: [require("@tailwindcss/typography"), require("@tailwindcss/aspect-ratio"), require("@tailwindcss/line-clamp")],
 }


### PR DESCRIPTION
Removes tailwind-forms plugin (https://github.com/tailwindlabs/tailwindcss-forms). It is very greedy on form styling & other projects importing `algorand-wallet-selector` should not need to override it.